### PR TITLE
Fixed crash on game win

### DIFF
--- a/Scripts/tower_ext_view.gd
+++ b/Scripts/tower_ext_view.gd
@@ -25,4 +25,4 @@ func progress_shadows():
 	
 func regress_shadows():
 	tower_progress -= 7 if tower_progress-7 > 0 else 0
-	tower.player("tower_"+str(tower_progress))
+	tower.play("tower_"+str(tower_progress))


### PR DESCRIPTION
- Fixed a crash caused by tower_ext_view calling "tower.player()" instead of "tower.play()"